### PR TITLE
Removing southcentral us region

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Form input parameters for configuring a bundle for deployment.
   - **`region`** *(string)*: The region where the OpenAI service will be deployed.
     - **One of**
       - East US
-      - South Central US
       - West Europe
 <!-- PARAMS:END -->
 

--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -24,8 +24,6 @@ params:
           oneOf:
             - title: East US
               const: eastus
-            - title: South Central US
-              const: southcentralus
             - title: West Europe
               const: westeurope
 


### PR DESCRIPTION
`southcentralus` is no longer supported by Azure, the API is now rejecting all requests. Removing it from the options available.